### PR TITLE
Добавил Symfony Crawler, исправил название пакета cagartner/phpquery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
     "yiisoft/yii2-bootstrap": "~2.0.0",
     "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0",
     "linslin/yii2-curl": "^1.4",
-    "ecagartner/phpquery": "^0.9.12",
-    "lanfix/parser": "*"
+    "cagartner/phpquery": "^0.9.12",
+    "lanfix/parser": "*",
+    "symfony/dom-crawler": "^5.1"
   },
   "config": {
     "process-timeout": 1800,


### PR DESCRIPTION
Composer не нашел пакета с названием "ecagartner/phpquery", но есть пакет "cagartner/phpquery", похоже на опечатку.