### PR TITLE
парсер moscowchanges.ru + фиксы для предыдущих

### DIFF
--- a/components/helper/TyRunBaseParser.php
+++ b/components/helper/TyRunBaseParser.php
@@ -233,7 +233,7 @@ abstract class TyRunBaseParser
         }
 
         $nodeSentences = array_map(function ($item) {
-            return !empty($item) ? trim($item, '  \t\n\r\0\x0B.') : false;
+            return !empty($item) ? trim($item, '  \t\n\r\0\x0B.') : null;
         }, explode('.', $node->text()));
         $intersect = array_intersect($nodeSentences, $descriptionSentences);
 
@@ -246,6 +246,7 @@ abstract class TyRunBaseParser
              * кроме html символов
              */
             $text = trim(implode('. ', array_diff($nodeSentences, $intersect)));
+
             if (empty(self::sanitizeHtmlEntities($text)) || stristr($newPost->description, $text)) {
                 return;
             }
@@ -295,7 +296,7 @@ abstract class TyRunBaseParser
         if ($pattern) {
             preg_match($pattern, $description, $matches);
         }
-        return !empty($matches[1]) ? html_entity_decode($matches[1]) : $description;
+        return !empty($matches[1]) ? html_entity_decode($matches[1]) : html_entity_decode($description);
     }
 
     /**

--- a/components/helper/TyRunBaseParser.php
+++ b/components/helper/TyRunBaseParser.php
@@ -119,6 +119,29 @@ abstract class TyRunBaseParser
     }
 
     /**
+     * Парсим заголовки
+     * @param Crawler $node
+     * @param NewsPost $newPost
+     */
+    protected static function parseHeader(Crawler $node, NewsPost $newPost): void
+    {
+        $content = $node->text();
+        $lvl = preg_match('/d/', $node->nodeName(), $matches);
+        if ($lvl && $lvl <= 6 && $content) {
+            $newPost->addItem(
+                new NewsPostItem(
+                    NewsPostItem::TYPE_HEADER,
+                    $content,
+                    null,
+                    null,
+                    $lvl,
+                    null
+                ));
+        }
+
+    }
+
+    /**
      * Возвращает id видео на youtube из url, если он есть
      * @param string $str
      * @return string|null
@@ -139,15 +162,16 @@ abstract class TyRunBaseParser
      * Приводим дату к UTC +0
      * @param string $date
      * @param string $format
-     * @return string
+     * @param bool $asDateTimeObject
+     * @return string|DateTime
      */
-    protected static function stringToDateTime(string $date, string $format = 'D, d M Y H:i:s O'): string
+    protected static function stringToDateTime(string $date, string $format = 'D, d M Y H:i:s O', $asDateTimeObject = false)
     {
         $dateTime = DateTime::createFromFormat($format, $date);
         if (is_a($dateTime, DateTime::class)) {
             $tz = new DateTimeZone('UTC');
             $dateTime->setTimezone($tz);
-            return $dateTime->format('d-m-Y H:i:s');
+            return $asDateTimeObject ? $dateTime : $dateTime->format('d-m-Y H:i:s');
         }
         return $date;
     }
@@ -277,7 +301,20 @@ abstract class TyRunBaseParser
      */
     protected static function sanitizeHtmlEntities(string $str): string
     {
-       return preg_replace("/&#?[a-z0-9]{2,8};/i","", htmlentities($str));
+        return preg_replace("/&#?[a-z0-9]{2,8};/i", "", htmlentities($str));
+    }
+
+    /**
+     * Заменяет название русских месяце в на их порядковый номер месяца без ведущего нуля
+     * @param string $str
+     * @return string
+     */
+    protected static function rusMonthToIndex(string $str): string
+    {
+        $months = ['января', 'февраля', 'марта', 'апреля', 'мая', 'июня', 'июля', 'августа', 'сентября', 'октября', 'ноября', 'декабря'];
+        $indexes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+        return str_replace($months, $indexes, $str);
     }
 
 }

--- a/components/helper/TyRunBaseParser.php
+++ b/components/helper/TyRunBaseParser.php
@@ -105,17 +105,20 @@ abstract class TyRunBaseParser
     {
         $src = self::getProperImageSrc($node, $lazySrcAttr);
         if ($src && $src != $newPost->image) {
-            $newPost->addItem(
-                new NewsPostItem(
-                    NewsPostItem::TYPE_IMAGE,
-                    null,
-                    $src,
-                    null,
-                    null,
-                    null
-                ));
+            if (empty($newPost->image)) {
+                $newPost->image = $src;
+            } else {
+                $newPost->addItem(
+                    new NewsPostItem(
+                        NewsPostItem::TYPE_IMAGE,
+                        null,
+                        $src,
+                        null,
+                        null,
+                        null
+                    ));
+            }
         }
-
     }
 
     /**
@@ -291,7 +294,7 @@ abstract class TyRunBaseParser
         if ($pattern) {
             preg_match($pattern, $description, $matches);
         }
-        return !empty($matches[1]) ? $matches[1] : $description;
+        return !empty($matches[1]) ? html_entity_decode($matches[1]) : $description;
     }
 
     /**

--- a/components/helper/TyRunBaseParser.php
+++ b/components/helper/TyRunBaseParser.php
@@ -198,7 +198,12 @@ abstract class TyRunBaseParser
      */
     protected static function parseDescriptionIntersectParagraph(Crawler $node, NewsPost $newPost, array $descriptionSentences): void
     {
-        if (empty($node->text())) return;
+        /**
+         * Пропускаем, если строка состоит только из html символов (например &nbsp;) либо пустая изначально
+         */
+        if (empty($node->text()) || empty(trim(self::sanitizeHtmlEntities($node->text())))) {
+            return;
+        }
 
         $nodeSentences = array_map(function ($item) {
             return !empty($item) ? trim($item, '  \t\n\r\0\x0B.') : false;
@@ -263,6 +268,16 @@ abstract class TyRunBaseParser
             preg_match($pattern, $description, $matches);
         }
         return !empty($matches[1]) ? $matches[1] : $description;
+    }
+
+    /**
+     * Убирает из строки html мнемоники
+     * @param string $str
+     * @return string
+     */
+    protected static function sanitizeHtmlEntities(string $str): string
+    {
+       return preg_replace("/&#?[a-z0-9]{2,8};/i","", htmlentities($str));
     }
 
 }

--- a/components/helper/TyRunBaseParser.php
+++ b/components/helper/TyRunBaseParser.php
@@ -242,10 +242,11 @@ abstract class TyRunBaseParser
          */
         if (!empty($node->text()) && count($intersect) < count($nodeSentences)) {
             /**
-             * Дополнительно проверяем, что оставшийся текст не является подстрокой описания
+             * Дополнительно проверяем, что оставшийся текст не является подстрокой описания и содержит что еще,
+             * кроме html символов
              */
             $text = trim(implode('. ', array_diff($nodeSentences, $intersect)));
-            if (empty($text) || stristr($newPost->description, $text)) {
+            if (empty(self::sanitizeHtmlEntities($text)) || stristr($newPost->description, $text)) {
                 return;
             }
 

--- a/components/parser/news/ArbuzToday.php
+++ b/components/parser/news/ArbuzToday.php
@@ -20,6 +20,8 @@ class ArbuzToday extends TyRunBaseParser implements ParserInterface
     const USER_ID = 2;
     const FEED_ID = 2;
 
+    const MAIN_PAGE_URI = 'https://arbuztoday.ru';
+
     /**
      * CSS класс, где хранится содержимое новости
      */
@@ -104,7 +106,7 @@ class ArbuzToday extends TyRunBaseParser implements ParserInterface
                 $mainImage = $newsContent->filter('.news-single-prev img');
                 if ($mainImage->count()) {
                     if ($mainImage->attr('src')) {
-                        $newPost->image = $mainImage->attr('src');
+                        $newPost->image = self::urlEncode($mainImage->attr('src'));
                     }
                 }
 
@@ -187,7 +189,7 @@ class ArbuzToday extends TyRunBaseParser implements ParserInterface
                 }
                 break;
             case 'p':
-                self::parseParagraph($node, $newPost, $descriptionSentences);
+                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
                 if ($nodes = $node->children()) {
                     $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
                         self::parseNode($node, $newPost, $maxDepth, $stopParsing);
@@ -220,49 +222,6 @@ class ArbuzToday extends TyRunBaseParser implements ParserInterface
         }
 
 
-    }
-
-    /**
-     * Парсер для тегов <p>
-     * Дополнительно сверяем содержимое тегов с описанием новости (по предложениям), дубли не добавляем
-     * @param Crawler $node текущий элемент для парсинга
-     * @param NewsPost $newPost объект новости
-     * @param array $descriptionSentences массив предложений описания новости
-     */
-    private static function parseParagraph(Crawler $node, NewsPost $newPost, array $descriptionSentences): void
-    {
-        $nodeSentences = array_map(function ($item) {
-            return !empty($item) ? trim($item, '  \t\n\r\0\x0B.') : false;
-        }, explode('.', $node->text()));
-        $intersect = array_intersect($nodeSentences, $descriptionSentences);
-
-        /**
-         * Если в тексте есть хоть одно уникальное предложение ( по сравнению с описанием новости )
-         */
-        if (!empty($node->text()) && count($intersect) < count($nodeSentences)) {
-            /**
-             * Дополнительно проверяем, что оставшийся текст не является подстрокой описания
-             */
-            $text = implode('. ', array_diff($nodeSentences, $intersect));
-            if (empty($text) || stristr($newPost->description, $text)) {
-                return;
-            }
-
-            $type = NewsPostItem::TYPE_TEXT;
-            if ($node->nodeName() == self::QUOTE_TAG) {
-                $type = NewsPostItem::TYPE_QUOTE;
-            }
-
-            $newPost->addItem(
-                new NewsPostItem(
-                    $type,
-                    $text,
-                    null,
-                    null,
-                    null,
-                    null
-                ));
-        }
     }
 
 }

--- a/components/parser/news/Info4s.php
+++ b/components/parser/news/Info4s.php
@@ -188,8 +188,8 @@ class Info4s extends TyRunBaseParser implements ParserInterface
             case 'span':
                 $nodes = $node->children();
                 if ($nodes->count()) {
-                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                     });
                 }
                 break;

--- a/components/parser/news/Kuzbass.php
+++ b/components/parser/news/Kuzbass.php
@@ -162,8 +162,6 @@ class Kuzbass extends TyRunBaseParser implements ParserInterface
 
         switch ($node->nodeName()) {
             case 'div': //запускаем рекурсивно на дочерние ноды, если есть, если нет то там обычно ненужный шлак
-            case 'span':
-                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
                 $nodes = $node->children();
                 if ($nodes->count()) {
                     $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
@@ -179,6 +177,11 @@ class Kuzbass extends TyRunBaseParser implements ParserInterface
             case 'blockquote':
             case 'p':
                 self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
+                if ($nodes = $node->children()) {
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    });
+                }
                 break;
             case 'img':
                 self::parseImage($node, $newPost);

--- a/components/parser/news/Kuzbass.php
+++ b/components/parser/news/Kuzbass.php
@@ -1,0 +1,211 @@
+<?php
+
+
+namespace app\components\parser\news;
+
+use app\components\Helper;
+use app\components\helper\TyRunBaseParser;
+use app\components\parser\NewsPost;
+use app\components\parser\NewsPostItem;
+use app\components\parser\ParserInterface;
+use Exception;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Парсер новостей из RSS ленты kuzbass85.ru
+ *
+ */
+class Kuzbass extends TyRunBaseParser implements ParserInterface
+{
+    const USER_ID = 2;
+    const FEED_ID = 2;
+
+    const MAIN_PAGE_URI = 'http://kuzbass85.ru';
+
+    /**
+     * CSS класс, где хранится содержимое новости
+     */
+    const BODY_CONTAINER_CSS_SELECTOR = '.inner_article';
+
+    /**
+     * CSS  класс для параграфов - цитат
+     */
+    const QUOTE_TAG = 'blockquote';
+
+    /**
+     * Классы эоементов, которые не нужно парсить, например блоки с рекламой и т.п.
+     * в формате RegExp
+     */
+    const EXCLUDE_CSS_CLASSES_PATTERN = '';
+
+    /**
+     * Класс элемента после которого парсить страницу не имеет смысла (контент статьи закончился)
+     */
+    const CUT_CSS_CLASS = '';
+
+
+    /**
+     * Ссылка на RSS фид (XML)
+     */
+    const FEED_URL = 'http://kuzbass85.ru/rss';
+
+    /**
+     *  Максимальная глубина для парсинга <div> тегов
+     */
+    const MAX_PARSE_DEPTH = 3;
+
+    /**
+     * Префикс для элементов списков (ul, ol и т.п.)
+     * при преобразовании в текст
+     * @see parseUl()
+     */
+    const UL_PREFIX = '-';
+
+    /**
+     * Кол-во новостей, которое необходимо парсить
+     */
+    const MAX_NEWS_COUNT = 10;
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public static function run(): array
+    {
+        $posts = [];
+        $curl = Helper::getCurl();
+        $rss = $curl->get(self::FEED_URL);
+
+        $crawler = new Crawler($rss);
+        $crawler->filter('rss channel item')->slice(0, self::MAX_NEWS_COUNT)->each(function (Crawler $node) use (&$pubTimeArray, &$curl, &$posts) {
+
+            $newPost = new NewsPost(
+                self::class,
+                $node->filter('title')->text(),
+                self::prepareDescription($node->filter('description')->text(),
+                    '/(.*)\.(.*)(&#8230;)(.*)/'),
+                date('Y-m-d H:i:s'),
+                $node->filter('link')->text(),
+                self::urlEncode($node->filter('enclosure')->attr('url'))
+            );
+
+            /**
+             * Предложения содержащиеся в описании (для последующей проверки при парсинга тела новости)
+             */
+            $descriptionSentences = explode('. ', html_entity_decode($newPost->description));
+
+            /**
+             * Получаем полный html новости
+             */
+            $newsContent = $curl->get($newPost->original);
+
+
+            if (!empty($newsContent)) {
+                $newsContent = (new Crawler($newsContent))->filter(self::BODY_CONTAINER_CSS_SELECTOR);
+
+                $authorString = $newsContent->filter('.author_info')->text();
+                $pubDate = self::rusMonthToIndex(explode(' | ', $authorString)[0]);
+                $dateString = $pubDate . ' ' . date('H:i:s O');
+                $newPost->createDate = self::stringToDateTime($dateString, 'd n Y H:i:s O', true);;
+
+                /**
+                 * Текст статьи, может содержать цитаты ( все полезное содержимое в тегах <p> )
+                 * Не знаю нужно или нет, но сделал более универсально, с рекурсией
+                 */
+                $articleContent = $newsContent->filter('.font_size_options')->children();
+                $stopParsing = false;
+                if ($articleContent->count()) {
+                    $articleContent->each(function ($node) use ($newPost, &$stopParsing, $descriptionSentences) {
+                        if ($stopParsing) {
+                            return;
+                        }
+                        self::parseNode($node, $newPost, self::MAX_PARSE_DEPTH, $stopParsing, $descriptionSentences);
+                    });
+                }
+            }
+
+            $posts[] = $newPost;
+        });
+
+        return $posts;
+    }
+
+    protected static function parseNode(Crawler $node, NewsPost $newPost, int $maxDepth, bool &$stopParsing, $descriptionSentences = []): void
+    {
+        /**
+         * Пропускаем элемент, если элемент имеет определенный класс
+         * @see EXCLUDE_CSS_CLASSES_PATTERN
+         */
+        if (self::EXCLUDE_CSS_CLASSES_PATTERN
+            && preg_match(self::EXCLUDE_CSS_CLASSES_PATTERN, $node->attr('class'))) {
+            return;
+        }
+
+        /**
+         * Прекращаем парсить страницу, если дошли до конца статьи
+         * (до определенного элемента с классом указанным в @see CUT_CSS_CLASS )
+         *
+         */
+        if (self::CUT_CSS_CLASS && stristr($node->attr('class'), self::CUT_CSS_CLASS)) {
+            $maxDepth = 0;
+            $stopParsing = true;
+        }
+
+        /**
+         * Ограничение максимальной глубины парсинга
+         * @see MAX_PARSE_DEPTH
+         */
+        if (!$maxDepth) {
+            return;
+        }
+        $maxDepth--;
+
+        switch ($node->nodeName()) {
+            case 'div': //запускаем рекурсивно на дочерние ноды, если есть, если нет то там обычно ненужный шлак
+            case 'span':
+                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
+                $nodes = $node->children();
+                if ($nodes->count()) {
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    });
+                }
+                break;
+            case 'h3':
+            case 'h4':
+            case 'h5':
+                self::parseHeader($node, $newPost);
+                break;
+            case 'blockquote':
+            case 'p':
+                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
+                break;
+            case 'img':
+                self::parseImage($node, $newPost);
+                break;
+            case 'video':
+                $videoId = self::extractYouTubeId($node->filter('source')->first()->attr('src'));
+                self::addVideo($videoId, $newPost);
+                break;
+            case 'a':
+                self::parseLink($node, $newPost);
+                if ($nodes = $node->children()) {
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    });
+                }
+                break;
+            case 'iframe':
+                $videoId = self::extractYouTubeId($node->attr('src'));
+                self::addVideo($videoId, $newPost);
+                break;
+            case 'ul':
+            case 'ol':
+                self::parseUl($node, $newPost);
+                break;
+        }
+
+
+    }
+
+}

--- a/components/parser/news/Kuzbass.php
+++ b/components/parser/news/Kuzbass.php
@@ -165,8 +165,8 @@ class Kuzbass extends TyRunBaseParser implements ParserInterface
             case 'div': //запускаем рекурсивно на дочерние ноды, если есть, если нет то там обычно ненужный шлак
                 $nodes = $node->children();
                 if ($nodes->count()) {
-                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                     });
                 }
                 break;
@@ -179,8 +179,8 @@ class Kuzbass extends TyRunBaseParser implements ParserInterface
             case 'p':
                 self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
                 if ($nodes = $node->children()) {
-                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                     });
                 }
                 break;

--- a/components/parser/news/OmskPress.php
+++ b/components/parser/news/OmskPress.php
@@ -80,7 +80,8 @@ class OmskPress extends TyRunBaseParser implements ParserInterface
             $newPost = new NewsPost(
                 self::class,
                 $node->filter('title')->text(),
-                self::prepareDescription($node->filter('description')->text()),
+                self::prepareDescription($node->filter('description')->text(),
+                    '/(.*)\.(.*)(\[&#8230;]|Сообщение)(.*)ОмскПресс\./'),
                 self::stringToDateTime($node->filter('pubDate')->text()),
                 $node->filter('link')->text(),
                 null
@@ -269,23 +270,6 @@ class OmskPress extends TyRunBaseParser implements ParserInterface
                     null
                 ));
         }
-    }
-
-
-    /**
-     * В RSS битый дескрипшн, в конце всегда идет коприайт, в виде ссылки на сайт
-     * Например ( после обработки @param string $description
-     * @return mixed
-     * @see Helper::prepareString ) :
-     * [&#8230;] The post В Тверской области лишили прав водителя, ездившего " под кайфом" first appeared on TVTver.ru.
-     * Обрезаем описание до последнего законченного предложения
-     *
-     */
-    private static function prepareDescription(string $description): string
-    {
-        $description = Helper::prepareString($description);
-        preg_match('/(.*)\.(.*)(\[&#8230;]|Сообщение)(.*)ОмскПресс\./', $description, $matches);
-        return !empty($matches[1]) ? $matches[1] : $description;
     }
 
 }

--- a/components/parser/news/Pnz1.php
+++ b/components/parser/news/Pnz1.php
@@ -1,0 +1,212 @@
+<?php
+
+
+namespace app\components\parser\news;
+
+use app\components\Helper;
+use app\components\helper\TyRunBaseParser;
+use app\components\parser\NewsPost;
+use app\components\parser\NewsPostItem;
+use app\components\parser\ParserInterface;
+use Exception;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Парсер новостей из RSS ленты 4s-info.ru
+ *
+ */
+class Pnz1 extends TyRunBaseParser implements ParserInterface
+{
+    const USER_ID = 2;
+    const FEED_ID = 2;
+
+    const MAIN_PAGE_URI = 'https://1pnz.ru';
+
+    /**
+     * CSS класс, где хранится содержимое новости
+     */
+    const BODY_CONTAINER_CSS_SELECTOR = '.simple_html';
+
+    /**
+     * CSS  класс для параграфов - цитат
+     */
+    const QUOTE_TAG = 'em';
+
+    /**
+     * Классы эоементов, которые не нужно парсить, например блоки с рекламой и т.п.
+     * в формате RegExp
+     */
+    const EXCLUDE_CSS_CLASSES_PATTERN = '';
+
+    /**
+     * Класс элемента после которого парсить страницу не имеет смысла (контент статьи закончился)
+     */
+    const CUT_CSS_CLASS = 'ya-share2';
+
+
+    /**
+     * Ссылка на RSS фид (XML)
+     */
+    const FEED_URL = 'https://1pnz.ru/rss';
+
+    /**
+     *  Максимальная глубина для парсинга <div> тегов
+     */
+    const MAX_PARSE_DEPTH = 3;
+
+    /**
+     * Префикс для элементов списков (ul, ol и т.п.)
+     * при преобразовании в текст
+     * @see parseUl()
+     */
+    const UL_PREFIX = '-';
+
+    /**
+     * Кол-во новостей, которое необходимо парсить
+     */
+    const MAX_NEWS_COUNT = 10;
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public static function run(): array
+    {
+        $posts = [];
+        $curl = Helper::getCurl();
+        $rss = $curl->get(self::FEED_URL);
+
+        $crawler = new Crawler($rss);
+        $crawler->filter('rss channel item')->slice(0, self::MAX_NEWS_COUNT)->each(function (Crawler $node) use (&$curl, &$posts) {
+
+            $newPost = new NewsPost(
+                self::class,
+                $node->filter('title')->text(),
+                self::prepareDescription($node->filter('description')->text(),
+                    '/(.*)\.(.*)(\[&#8230;])(.*)/'),
+                self::stringToDateTime($node->filter('pubDate')->text()),
+                $node->filter('link')->text(),
+                null
+            );
+
+            /**
+             * Предложения содержащиеся в описании (для последующей проверки при парсинга тела новости)
+             */
+            $descriptionSentences = explode('. ', html_entity_decode($newPost->description));
+
+            /**
+             * Получаем полный html новости
+             */
+            $newsContent = $curl->get($newPost->original);
+
+            if (!empty($newsContent)) {
+                $newsContent = (new Crawler($newsContent))->filter(self::BODY_CONTAINER_CSS_SELECTOR);
+                /**
+                 * Основное фото ( всегда одно в начале статьи)
+                 */
+                $mainImage = $newsContent->filter('.fancy_popup_link img');
+                if ($mainImage->count()) {
+                    if ($mainImage->attr('src')) {
+                        $newPost->image = self::urlEncode($mainImage->attr('src'));
+                    }
+                }
+
+                /**
+                 * Текст статьи, может содержать цитаты ( все полезное содержимое в тегах <p> )
+                 * Не знаю нужно или нет, но сделал более универсально, с рекурсией
+                 */
+                $articleContent = $newsContent->filter('.theme_day')->children();
+                $stopParsing = false;
+                if ($articleContent->count()) {
+                    $articleContent->each(function ($node) use ($newPost, &$stopParsing, $descriptionSentences) {
+                        if ($stopParsing) {
+                            return;
+                        }
+                        self::parseNode($node, $newPost, self::MAX_PARSE_DEPTH, $stopParsing, $descriptionSentences);
+                    });
+                }
+            }
+
+            $posts[] = $newPost;
+        });
+
+        return $posts;
+    }
+
+    protected static function parseNode(Crawler $node, NewsPost $newPost, int $maxDepth, bool &$stopParsing, $descriptionSentences = []): void
+    {
+        /**
+         * Пропускаем элемент, если элемент имеет определенный класс
+         * @see EXCLUDE_CSS_CLASSES_PATTERN
+         */
+        if (self::EXCLUDE_CSS_CLASSES_PATTERN
+            && preg_match(self::EXCLUDE_CSS_CLASSES_PATTERN, $node->attr('class'))) {
+            return;
+        }
+
+        /**
+         * Прекращаем парсить страницу, если дошли до конца статьи
+         * (до определенного элемента с классом указанным в @see CUT_CSS_CLASS )
+         *
+         */
+        if (self::CUT_CSS_CLASS && stristr($node->attr('class'), self::CUT_CSS_CLASS)) {
+            $maxDepth = 0;
+            $stopParsing = true;
+        }
+
+        /**
+         * Ограничение максимальной глубины парсинга
+         * @see MAX_PARSE_DEPTH
+         */
+        if (!$maxDepth) {
+            return;
+        }
+        $maxDepth--;
+
+        if (stristr($node->text(), 'Фото: ')) {
+            return;
+        }
+
+        switch ($node->nodeName()) {
+            case 'div': //запускаем рекурсивно на дочерние ноды, если есть, если нет то там обычно ненужный шлак
+            case 'span':
+                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
+                $nodes = $node->children();
+                if ($nodes->count()) {
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    });
+                }
+                break;
+            case 'p':
+                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
+                break;
+            case 'img':
+                self::parseImage($node, $newPost);
+                break;
+            case 'video':
+                $videoId = self::extractYouTubeId($node->filter('source')->first()->attr('src'));
+                self::addVideo($videoId, $newPost);
+                break;
+            case 'a':
+                self::parseLink($node, $newPost);
+                if ($nodes = $node->children()) {
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    });
+                }
+                break;
+            case 'iframe':
+                $videoId = self::extractYouTubeId($node->attr('src'));
+                self::addVideo($videoId, $newPost);
+                break;
+            case 'ul':
+            case 'ol':
+                self::parseUl($node, $newPost);
+                break;
+        }
+
+
+    }
+
+}

--- a/components/parser/news/SutyNews.php
+++ b/components/parser/news/SutyNews.php
@@ -178,8 +178,8 @@ class SutyNews extends TyRunBaseParser implements ParserInterface
                 } else {
                     $nodes = $node->children();
                     if ($nodes->count()) {
-                        $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                            self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                        $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                            self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                         });
                     }
                 }
@@ -188,8 +188,8 @@ class SutyNews extends TyRunBaseParser implements ParserInterface
             case 'p':
                 self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
                 if ($nodes = $node->children()) {
-                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                     });
                 }
                 break;

--- a/components/parser/news/TvTver.php
+++ b/components/parser/news/TvTver.php
@@ -80,7 +80,8 @@ class TvTver extends TyRunBaseParser implements ParserInterface
             $newPost = new NewsPost(
                 self::class,
                 $node->filter('title')->text(),
-                self::prepareDescription($node->filter('description')->text()),
+                self::prepareDescription($node->filter('description')->text(),
+                    '/(.*)\.(.*)(\[&#8230;]|The post)(.*)TVTver\.ru\./'),
                 self::stringToDateTime($node->filter('pubDate')->text()),
                 $node->filter('link')->text(),
                 null
@@ -247,24 +248,6 @@ class TvTver extends TyRunBaseParser implements ParserInterface
                     null
                 ));
         }
-    }
-
-
-
-    /**
-     * В RSS битый дескрипшн, в конце всегда идет коприайт, в виде ссылки на сайт
-     * Например ( после обработки @see Helper::prepareString ) :
-     * [&#8230;] The post В Тверской области лишили прав водителя, ездившего " под кайфом" first appeared on TVTver.ru.
-     * Обрезаем описание до последнего законченного предложения
-     *
-     * @param string $description
-     * @return mixed
-     */
-    private static function prepareDescription(string $description): string
-    {
-        $description = Helper::prepareString($description);
-        preg_match('/(.*)\.(.*)(\[&#8230;]|The post)(.*)TVTver\.ru\./', $description, $matches);
-        return !empty($matches[1]) ? $matches[1] : $description;
     }
 
 }

--- a/components/parser/news/VseNovostiNt.php
+++ b/components/parser/news/VseNovostiNt.php
@@ -1,0 +1,221 @@
+<?php
+
+
+namespace app\components\parser\news;
+
+use app\components\Helper;
+use app\components\helper\TyRunBaseParser;
+use app\components\parser\NewsPost;
+use app\components\parser\NewsPostItem;
+use app\components\parser\ParserInterface;
+use Exception;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Парсер новостей из RSS ленты vsenovostint.ru
+ *
+ * В RSS description попадает весь контент страницы без картинок, урезаем.
+ */
+class VseNovostiNt extends TyRunBaseParser implements ParserInterface
+{
+    const USER_ID = 2;
+    const FEED_ID = 2;
+
+    const MAIN_PAGE_URI = 'https://vsenovostint.ru';
+
+    /**
+     * CSS класс, где хранится содержимое новости
+     */
+    const BODY_CONTAINER_CSS_SELECTOR = 'article';
+
+    /**
+     * CSS  класс для параграфов - цитат
+     */
+    const QUOTE_TAG = 'blockquote';
+
+    /**
+     * Классы эоементов, которые не нужно парсить, например блоки с рекламой и т.п.
+     * в формате RegExp
+     */
+    const EXCLUDE_CSS_CLASSES_PATTERN = '';
+
+    /**
+     * Класс элемента после которого парсить страницу не имеет смысла (контент статьи закончился)
+     */
+    const CUT_CSS_CLASS = 'ya-share2';
+
+
+    /**
+     * Ссылка на RSS фид (XML)
+     */
+    const FEED_URL = 'https://vsenovostint.ru/feed/';
+
+    /**
+     *  Максимальная глубина для парсинга <div> тегов
+     */
+    const MAX_PARSE_DEPTH = 3;
+
+    /**
+     * Префикс для элементов списков (ul, ol и т.п.)
+     * при преобразовании в текст
+     * @see parseUl()
+     */
+    const UL_PREFIX = '-';
+
+    /**
+     * Кол-во новостей, которое необходимо парсить
+     */
+    const MAX_NEWS_COUNT = 10;
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public static function run(): array
+    {
+        $posts = [];
+        $curl = Helper::getCurl();
+        $rss = $curl->get(self::FEED_URL);
+
+        $crawler = new Crawler($rss);
+        $crawler->filter('rss channel item')->slice(0, self::MAX_NEWS_COUNT)->each(function (Crawler $node) use (&$curl, &$posts) {
+
+            $newPost = new NewsPost(
+                self::class,
+                $node->filter('title')->text(),
+                self::prepareDescription($node->filter('description')->text(),
+                    '/(.*)\.(.*)(The post)(.*)/'),
+                self::stringToDateTime($node->filter('pubDate')->text()),
+                $node->filter('link')->text(),
+                null
+            );
+
+            /**
+             * Предложения содержащиеся в описании (для последующей проверки при парсинга тела новости)
+             */
+            $descriptionSentences = explode('. ', html_entity_decode($newPost->description));
+            if (count($descriptionSentences) > 4) {
+                $descriptionSentences = array_slice($descriptionSentences, 0, 4);
+                $newPost->description = implode('. ', $descriptionSentences);
+            }
+
+            /**
+             * Получаем полный html новости
+             */
+            $newsContent = $curl->get($newPost->original);
+
+            if (!empty($newsContent)) {
+                $newsContent = (new Crawler($newsContent))->filter(self::BODY_CONTAINER_CSS_SELECTOR);
+
+                /**
+                 * Текст статьи, может содержать цитаты ( все полезное содержимое в тегах <p> )
+                 * Не знаю нужно или нет, но сделал более универсально, с рекурсией
+                 */
+                $articleContent = $newsContent->filter('.js-mediator-article')->children();
+                $stopParsing = false;
+                if ($articleContent->count()) {
+                    $articleContent->each(function ($node) use ($newPost, &$stopParsing, $descriptionSentences) {
+                        if ($stopParsing) {
+                            return;
+                        }
+                        self::parseNode($node, $newPost, self::MAX_PARSE_DEPTH, $stopParsing, $descriptionSentences);
+                    });
+                }
+            }
+
+            $posts[] = $newPost;
+        });
+
+        return $posts;
+    }
+
+    protected static function parseNode(Crawler $node, NewsPost $newPost, int $maxDepth, bool &$stopParsing, $descriptionSentences = []): void
+    {
+        /**
+         * Пропускаем элемент, если элемент имеет определенный класс
+         * @see EXCLUDE_CSS_CLASSES_PATTERN
+         */
+        if (self::EXCLUDE_CSS_CLASSES_PATTERN
+            && preg_match(self::EXCLUDE_CSS_CLASSES_PATTERN, $node->attr('class'))) {
+            return;
+        }
+
+        /**
+         * Прекращаем парсить страницу, если дошли до конца статьи
+         * (до определенного элемента с классом указанным в @see CUT_CSS_CLASS )
+         *
+         */
+        if (self::CUT_CSS_CLASS && stristr($node->attr('class'), self::CUT_CSS_CLASS)) {
+            $maxDepth = 0;
+            $stopParsing = true;
+        }
+
+        /**
+         * Ограничение максимальной глубины парсинга
+         * @see MAX_PARSE_DEPTH
+         */
+        if (!$maxDepth) {
+            return;
+        }
+        $maxDepth--;
+
+        if ($node->text() == 'Поделиться:') {
+            return;
+        }
+
+        switch ($node->nodeName()) {
+            case 'div': //запускаем рекурсивно на дочерние ноды, если есть, если нет то там обычно ненужный шлак
+            case 'span':
+                /**
+                 * Новость может содержать галерею (блок с классом field-type-image),
+                 * парсим только изображения из таких блоков
+                 */
+                if (stristr($node->attr('class'), 'newsSlider')) {
+                    $images = $node->filter('.slides img');
+                    if ($images->count()) {
+                        $images->each(function (Crawler $node) use (&$newPost) {
+                            self::parseImage($node, $newPost);
+                        });
+                    }
+                } else {
+                    $nodes = $node->children();
+                    if ($nodes->count()) {
+                        $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                            self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                        });
+                    }
+                }
+                break;
+            case 'p':
+            case 'blockquote':
+                self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
+                break;
+            case 'img':
+                self::parseImage($node, $newPost);
+                break;
+            case 'video':
+                $videoId = self::extractYouTubeId($node->filter('source')->first()->attr('src'));
+                self::addVideo($videoId, $newPost);
+                break;
+            case 'a':
+                self::parseLink($node, $newPost);
+                if ($nodes = $node->children()) {
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    });
+                }
+                break;
+            case 'iframe':
+                $videoId = self::extractYouTubeId($node->attr('src'));
+                self::addVideo($videoId, $newPost);
+                break;
+            case 'ul':
+            case 'ol':
+                self::parseUl($node, $newPost);
+                break;
+        }
+
+
+    }
+
+}

--- a/components/parser/news/VseNovostiNt.php
+++ b/components/parser/news/VseNovostiNt.php
@@ -180,8 +180,8 @@ class VseNovostiNt extends TyRunBaseParser implements ParserInterface
                 } else {
                     $nodes = $node->children();
                     if ($nodes->count()) {
-                        $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                            self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                        $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                            self::parseNode($node, $newPost, $maxDepth, $stopParsin, $descriptionSentences);
                         });
                     }
                 }

--- a/components/parser/news/YamalRegion.php
+++ b/components/parser/news/YamalRegion.php
@@ -162,8 +162,8 @@ class YamalRegion extends TyRunBaseParser implements ParserInterface
             case 'span':
                 $nodes = $node->children();
                 if ($nodes->count()) {
-                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                     });
                 } else {
                     self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
@@ -172,8 +172,8 @@ class YamalRegion extends TyRunBaseParser implements ParserInterface
             case 'p':
                 self::parseDescriptionIntersectParagraph($node, $newPost, $descriptionSentences);
                 if ($nodes = $node->children()) {
-                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing) {
-                        self::parseNode($node, $newPost, $maxDepth, $stopParsing);
+                    $nodes->each(function ($node) use ($newPost, $maxDepth, &$stopParsing, &$descriptionSentences) {
+                        self::parseNode($node, $newPost, $maxDepth, $stopParsing, $descriptionSentences);
                     });
                 }
                 break;


### PR DESCRIPTION
В некоторых парсерах при поиске в глубину не передавался массив предложений из описания - исправил.
Добавил  парсер moscowchanges.ru